### PR TITLE
fix: prevent bad optional access when hiding dots

### DIFF
--- a/Source/BlockGridComponent.cpp
+++ b/Source/BlockGridComponent.cpp
@@ -147,7 +147,7 @@ void BlockGridComponent::resized() {
 }
 
 void BlockGridComponent::hideDotsAroundIndex(GridItemComponent* blockComponent, Index index, int length, bool visible) {
-  if (!isIndexInside(*previousPlaceholderIndex)) return;
+  if (previousPlaceholderIndex.has_value() && !isIndexInside(*previousPlaceholderIndex)) return;
   for (int column = index.column; column < index.column + 1 + length; column++)
     for (int row = 0; row <= 1; row++)
       dots.getUnchecked(index.row + row)->getUnchecked(column)->setVisible(visible);


### PR DESCRIPTION
First item drag will access the previous placeholder optional without checking the value.