### PR TITLE
fix missed returns in non-void functions

### DIFF
--- a/Source/OscillatorPainter.h
+++ b/Source/OscillatorPainter.h
@@ -89,6 +89,7 @@ private:
     case WaveformType::noise:
       return 1.0f - 2.0f * rand() / RAND_MAX;
     }
+    return 0.f;
   }
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscillatorPainter)

--- a/Source/Tab.cpp
+++ b/Source/Tab.cpp
@@ -51,6 +51,7 @@ int Tab::stepColumn(Selection selection) {
     return rand() % length;
   default: jassertfalse;
   }
+  return 0;
 }
 
 Array<int> Tab::getAllColumns() {

--- a/Source/ValueAnimator.cpp
+++ b/Source/ValueAnimator.cpp
@@ -34,4 +34,5 @@ float ValueAnimator::getWaveform(float x) {
   case WaveType::was:
     return was(x);
   }
+  return 0.f;
 }

--- a/Source/WaveTableConstants.cpp
+++ b/Source/WaveTableConstants.cpp
@@ -267,4 +267,5 @@ WaveTable* WaveTableConstants::getWaveTable(WaveTableConstants::WaveTableType ty
   case WaveTableType::count:
     return nullptr;
   }
+  return nullptr;
 }


### PR DESCRIPTION
Hi,

This should fix compilation with `-Werror=return-type`