### PR TITLE
fix: change MidiKeyboardState ownership to processor

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -5,7 +5,7 @@
 #include "gui/ThemeManager.h"
 #include "settings/UserSettings.h"
 
-MainComponent::MainComponent(Delegate* delegate): delegate(delegate), uiLayer(this), tabGrid(GridConfigs::tab), blockGrid(GridConfigs::blocks) {
+MainComponent::MainComponent(juce::MidiKeyboardState& keyboard_state, Delegate* delegate): delegate(delegate), uiLayer(keyboard_state, this), tabGrid(GridConfigs::tab), blockGrid(GridConfigs::blocks) {
   setWantsKeyboardFocus(false);
 
   setLookAndFeel(&blocksLookAndFeel);

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -32,7 +32,7 @@ class MainComponent final: public Component,
 public:
   struct Delegate;
   Delegate* delegate;
-  MainComponent(Delegate* delegate);
+  MainComponent(juce::MidiKeyboardState& keyboard_state, Delegate* delegate);
   ~MainComponent() override;
   void mouseMove(const MouseEvent& event) override;
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -13,9 +13,8 @@
 void PluginEditor::paint(Graphics& g) { g.fillAll(Colour(28, 28, 28)); }
 void PluginEditor::resized() { mainComponent.setBounds(getLocalBounds()); }
 void PluginEditor::timerCallback() { }
-PluginEditor::~PluginEditor() { processor.keyboardState = nullptr; }
 
-PluginEditor::PluginEditor(PluginProcessor& p): AudioProcessorEditor(&p), processor(p), mainComponent(&p.synth) {
+PluginEditor::PluginEditor(juce::MidiKeyboardState& keyboard_state, PluginProcessor& p): AudioProcessorEditor(&p), processor(p), mainComponent(keyboard_state, &p.synth) {
   setSize(1200, 770);
 
   setResizable(false, false);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -19,8 +19,7 @@ private:
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginEditor)
 public:
   MainComponent mainComponent;
-  PluginEditor(PluginProcessor& processor);
-  ~PluginEditor();
+  PluginEditor(juce::MidiKeyboardState& keyboard_state, PluginProcessor& processor);
   void paint(Graphics&) override;
   void resized() override;
   void timerCallback() override;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -23,7 +23,6 @@ PluginProcessor::PluginProcessor(bool): AudioProcessor(BusesProperties().withOut
 
 void PluginProcessor::setup() {
   loadParameters();
-  keyboardState = nullptr;
   WaveTableConstants::load(44100);
   Analytics::shared()->initProfileIfNeeded();
   Analytics::shared()->handleLaunch(getWrapperTypeDescription(wrapperType));
@@ -41,9 +40,7 @@ void PluginProcessor::loadParameters() {
 void PluginProcessor::processBlock(AudioBuffer<float>& buffer, MidiBuffer& midiMessages) {
   updateHostInfo(buffer.getNumSamples());
 
-  if (keyboardState != nullptr && mainComponent != nullptr) {
-    keyboardState->processNextMidiBuffer(midiMessages, 0, buffer.getNumSamples(), true);
-  }
+  keyboard_state_.processNextMidiBuffer(midiMessages, 0, buffer.getNumSamples(), true);
 
   originalSize = buffer.getNumSamples();
   bufferSize = std::min(originalSize, 128);
@@ -127,8 +124,7 @@ void PluginProcessor::parameterValueChanged(int parameterIndex, float newValue) 
 }
 
 AudioProcessorEditor* PluginProcessor::createEditor() {
-  auto editor = new PluginEditor(*this);
-  keyboardState = &editor->mainComponent.uiLayer.keyboardState;
+  auto editor = new PluginEditor(keyboard_state_, *this);
   if (TopLevelWindow::getNumTopLevelWindows() == 1) {
     TopLevelWindow* w = TopLevelWindow::getTopLevelWindow(0);
     w->setUsingNativeTitleBar(true);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -10,7 +10,6 @@ using namespace Model;
 
 class PluginProcessor: public AudioProcessor, public AudioProcessorParameter::Listener {
 public:
-  MidiKeyboardState* keyboardState;
   Synth synth;
   double bpm = 120;
 
@@ -56,6 +55,7 @@ public:
   void updateHostInfo(int blockSize);
 
 private:
+  MidiKeyboardState keyboard_state_;
   MainComponent* mainComponent;
   void setup();
 };

--- a/Source/gui/UILayer.cpp
+++ b/Source/gui/UILayer.cpp
@@ -13,7 +13,8 @@
 #include "model/ModelConstants.h"
 #include "BinaryData.h"
 
-UILayer::UILayer(Slider::Listener* listener): keyboard(keyboardState, MidiKeyboardComponent::Orientation::horizontalKeyboard), ComponentMovementWatcher(this) {
+UILayer::UILayer(juce::MidiKeyboardState& keyboard_state, Slider::Listener* listener): 
+    keyboard(keyboard_state, MidiKeyboardComponent::Orientation::horizontalKeyboard), ComponentMovementWatcher(this) {
   addModulatorsButton();
   addAndMakeVisible(presetButton);
 

--- a/Source/gui/UILayer.h
+++ b/Source/gui/UILayer.h
@@ -33,7 +33,6 @@ public:
   SideMenu matrix;
   ModulatorsSideMenu modulators;
   PresetButtonComponent presetButton;
-  MidiKeyboardState keyboardState;
   KeyboardComponent keyboard;
 
   std::unique_ptr<SVGButton> settingsButton;
@@ -46,7 +45,7 @@ public:
 
   ModulationsListBoxModel modulationsListBoxModel;
 
-  UILayer(Slider::Listener* listener);
+  UILayer(juce::MidiKeyboardState& keyboard_state, Slider::Listener* listener);
   ~UILayer() override;
 
   void resized() override;
@@ -66,6 +65,8 @@ private:
   void showModulatorsSideMenu();
   void resizeSettingsButton();
   void resizeSaveAndNewButtons();
+
+private:
   int edgeMargin = 16;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(UILayer)


### PR DESCRIPTION
This will fix the race condition when opening/closing the plugin editor as the pointer was not atomic.
Keyboard state should always exist and be processed so it can catch all messages, this way when the editor appears all notes already ON will be ok.