### PR TITLE
fix(MainComponent.cpp): Fixed segmentation fault on unsuccessful version request

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -36,8 +36,10 @@ MainComponent::MainComponent(juce::MidiKeyboardState& keyboard_state, Delegate* 
 
   auto req = [this] {
     auto options = juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress);
-    auto version = juce::URL("https://blocksbucket.s3.us-east-2.amazonaws.com/version").createInputStream(options)->readEntireStreamAsString().toStdString();
-    juce::MessageManager::callAsync([this, version] { ui_layer_.update_button_.setVisible(version != BLOCKS_VERSION);});
+    if (auto inputStream = juce::URL("https://blocksbucket.s3.us-east-2.amazonaws.com/version").createInputStream(options); inputStream != nullptr) {
+      const auto version = inputStream->readEntireStreamAsString();
+      juce::MessageManager::callAsync([this, version] { ui_layer_.update_button_.setVisible(version != BLOCKS_VERSION);});
+    }
   };
 
   juce::Thread::launch(req);


### PR DESCRIPTION
- `decomposeURL` in the Linux JUCE backend cannot handle anything other than HTTP, see [here](https://github.com/juce-framework/JUCE/blob/master/modules/juce_core/native/juce_Network_linux.cpp#L562)
- The above caused a nullptr dereference in the version check routine, at least on Linux on every startup
  - The proper solution of course would be to implement HTTPS. According to the documentation, JUCE doesn't support this out of the box.
  - I'm sure that many cross-platform 3rd party options exist for that, but it is also not difficult to roll your own using platform specific dependencies. E.g. I did the latter in my own project: [Windows](https://github.com/mfep/midiconn/blob/main/src/PlatformUtilsWin.cpp#L96-L119), [Linux](https://github.com/mfep/midiconn/blob/main/src/PlatformUtilsLinux.cpp#L75-L100)
- I've added a check to avoid dereferencing the nullptr
- I think that this fixes #29 
- Thank you for creating this, keep it up! :heart: 