### PR TITLE
fix: preset loading for Bitwig

### DIFF
--- a/Source/blocks_plugin_processor.cpp
+++ b/Source/blocks_plugin_processor.cpp
@@ -286,7 +286,6 @@ void PluginProcessor::setStateInformation(const void* data, int size_in_bytes) {
   if (auto preset = preset_manager_.stringToPreset(preset_string.toStdString())) {
     if (engine_prepared_) {
       loadPreset(*preset);
-      if (editor_ready_) main_component_->loadState(*preset);
     } else {
       pending_preset_ = preset;
       // synth.presetToLoadOnInit = *preset;
@@ -473,6 +472,7 @@ void PluginProcessor::loadPreset(Preset preset) {
     // if (presetBlock.length > 1) {
       // expand(block->index, presetBlock.length - 1, true);
     // }
+    if (editor_ready_) main_component_->loadState(preset);
   }
 
   for (auto presetModulator : preset.modulators) {


### PR DESCRIPTION
When restoring a preset in Bitwig, not everything got updated, which resulted in problems with the patch including the levels not being set and an empty GUI the first time it's opened. This change just moves where one of the updates happens so it is consistent when the `pending_preset_` is used. It's unclear why this did not cause a problem in other hosts, but I only saw the issue in Bitwig. Apologies, but I really don't know a good way to write a test for this, otherwise I'd include one 😬 